### PR TITLE
fix: recursion tracing with memory cleanup (V2)

### DIFF
--- a/Backend/engines/execution_tracer.py
+++ b/Backend/engines/execution_tracer.py
@@ -27,10 +27,21 @@ def diff_locals(prev, curr):
 
 def trace_execution(code: str):
     events = []
-    last_locals = {}
+    
+    frame_history = {}
 
     def tracer(frame, event, arg):
-        nonlocal last_locals
+        frame_id = id(frame)
+
+        if event == 'return':
+            if frame_id in frame_history:
+                del frame_history[frame_id]
+            return tracer
+
+        if event != 'line':
+            return tracer
+
+        last_locals = frame_history.get(frame_id, {})
 
         if event == "line":
             raw_locals = {
@@ -47,7 +58,7 @@ def trace_execution(code: str):
                 "locals_all": raw_locals
             })
 
-            last_locals = raw_locals
+            frame_history[frame_id] = raw_locals
 
         return tracer
 


### PR DESCRIPTION
Fixes #2

**Context**
This is a revised fix for the recursion tracing issue.
The previous attempt correctly isolated stack frames using `id(frame)` but did not clear the history on return. This caused memory leaks and ID collisions when Python reused memory addresses for subsequent function calls.

**Changes**
1.  **Stack Frame Isolation:** Switched from a single `last_locals` variable to a `frame_history` dictionary keyed by `id(frame)`. This prevents child frames from overwriting parent state during recursion.
2.  **Memory Cleanup:** Added a listener for the `return` event to explicitly `del frame_history[id(frame)]`. This ensures resources are freed immediately and prevents ID collisions.